### PR TITLE
Redirect /v3/studies/* to v2 `studies` plugin.

### DIFF
--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -68,8 +68,8 @@
 
     <Location /v3/studies>
       Require all granted
-      ProxyPass  http://localhost:7478/db/data/ext/studies_v3/graphdb
-      ProxyPassReverse  http://localhost:7478/db/data/ext/studies_v3/graphdb
+      ProxyPass  http://localhost:7478/db/data/ext/studies/graphdb
+      ProxyPassReverse  http://localhost:7478/db/data/ext/studies/graphdb
     </Location>
 
     # 8081 = conflict service


### PR DESCRIPTION
This has been pointing to a more advanced `studies_v3`, but for now we're just keeping the methods and behavior from v2.