### PR TITLE
Changes for deploying v3 APIs

### DIFF
--- a/deploy/setup/install-web2py-apps.sh
+++ b/deploy/setup/install-web2py-apps.sh
@@ -87,9 +87,9 @@ cp -p $configtemplate $configfile
 
 # Append /cached to some API base URLs (for faster retrieval of common method calls)
 # N.B. We now expect these base URLs to be simple domain names, with no trailing path!
-CACHED_TREEMACHINE_BASE_URL=$(sed "s+$+/cached+" <<< $TREEMACHINE_BASE_URL)
-CACHED_TAXOMACHINE_BASE_URL=$(sed "s+$+/cached+" <<< $TAXOMACHINE_BASE_URL)
-CACHED_OTI_BASE_URL=$(sed "s+$+/cached+" <<< $OTI_BASE_URL)
+CACHED_TREEMACHINE_BASE_URL=$(sed "s+$+/phylesystem/cached+" <<< $TREEMACHINE_BASE_URL)
+CACHED_TAXOMACHINE_BASE_URL=$(sed "s+$+/phylesystem/cached+" <<< $TAXOMACHINE_BASE_URL)
+CACHED_OTI_BASE_URL=$(sed "s+$+/phylesystem/cached+" <<< $OTI_BASE_URL)
 
 sed "s+github_client_id = .*+github_client_id = $TREEVIEW_GITHUB_CLIENT_ID+;
      s+github_redirect_uri = .*+github_redirect_uri = $TREEVIEW_GITHUB_REDIRECT_URI+

--- a/deploy/setup/install-web2py-apps.sh
+++ b/deploy/setup/install-web2py-apps.sh
@@ -87,9 +87,9 @@ cp -p $configtemplate $configfile
 
 # Append /cached to some API base URLs (for faster retrieval of common method calls)
 # N.B. We now expect these base URLs to be simple domain names, with no trailing path!
-CACHED_TREEMACHINE_BASE_URL=$(sed "s+$+/phylesystem/cached+" <<< $TREEMACHINE_BASE_URL)
-CACHED_TAXOMACHINE_BASE_URL=$(sed "s+$+/phylesystem/cached+" <<< $TAXOMACHINE_BASE_URL)
-CACHED_OTI_BASE_URL=$(sed "s+$+/phylesystem/cached+" <<< $OTI_BASE_URL)
+CACHED_TREEMACHINE_BASE_URL=$(sed "s+$+/cached+" <<< $TREEMACHINE_BASE_URL)
+CACHED_TAXOMACHINE_BASE_URL=$(sed "s+$+/cached+" <<< $TAXOMACHINE_BASE_URL)
+CACHED_OTI_BASE_URL=$(sed "s+$+/cached+" <<< $OTI_BASE_URL)
 
 sed "s+github_client_id = .*+github_client_id = $TREEVIEW_GITHUB_CLIENT_ID+;
      s+github_redirect_uri = .*+github_redirect_uri = $TREEVIEW_GITHUB_REDIRECT_URI+

--- a/deploy/setup/install-web2py-apps.sh
+++ b/deploy/setup/install-web2py-apps.sh
@@ -85,9 +85,11 @@ echo "Triggering use of HTTPS from within web2py? [$SSL_CERTS_FOUND]"
 # Replace tokens in example config file to make the active config (assume this always changes)
 cp -p $configtemplate $configfile
 
-# Prepend /cached/ to some API base URLs (for faster retrieval of common method calls)
-CACHED_TREEMACHINE_BASE_URL=$(sed "s+treemachine/+cached/treemachine/+" <<< $TREEMACHINE_BASE_URL)
-CACHED_TAXOMACHINE_BASE_URL=$(sed "s+taxomachine/+cached/taxomachine/+" <<< $TAXOMACHINE_BASE_URL)
+# Append /cached to some API base URLs (for faster retrieval of common method calls)
+# N.B. We now expect these base URLs to be simple domain names, with no trailing path!
+CACHED_TREEMACHINE_BASE_URL=$(sed "s+$+/cached+" <<< $TREEMACHINE_BASE_URL)
+CACHED_TAXOMACHINE_BASE_URL=$(sed "s+$+/cached+" <<< $TAXOMACHINE_BASE_URL)
+CACHED_OTI_BASE_URL=$(sed "s+$+/cached+" <<< $OTI_BASE_URL)
 
 sed "s+github_client_id = .*+github_client_id = $TREEVIEW_GITHUB_CLIENT_ID+;
      s+github_redirect_uri = .*+github_redirect_uri = $TREEVIEW_GITHUB_REDIRECT_URI+
@@ -101,6 +103,7 @@ sed "s+github_client_id = .*+github_client_id = $TREEVIEW_GITHUB_CLIENT_ID+;
      s+conflict_api = .*+conflict_api = $CONFLICT_BASE_URL+
      s+CACHED_treemachine = .*+CACHED_treemachine = $CACHED_TREEMACHINE_BASE_URL+
      s+CACHED_taxomachine = .*+CACHED_taxomachine = $CACHED_TAXOMACHINE_BASE_URL+
+     s+CACHED_oti = .*+CACHED_oti = $CACHED_OTI_BASE_URL+
      s+secure_sessions_with_HTTPS = .*+secure_sessions_with_HTTPS = $SSL_CERTS_FOUND+
     " < $configfile > tmp.tmp
 mv tmp.tmp $configfile

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -34,13 +34,15 @@
     # Public v3 API (originally cloned from v2)
 
     # phylesystem-api is provided via web2py
+    # N.B. that we should match "bare" URLs like '/v3/study' to create a resource!
     RewriteEngine on
-    RewriteRule ^/v3/study/(.*) /phylesystem/v1/study/$1 [PT]
+    RewriteRule ^/v3/study(.*) /phylesystem/v1/study$1 [PT]
 
     # collections-api is provided via web2py
     RewriteEngine on
-    RewriteRule ^/v3/collections/(.*) /phylesystem/v1/collections/$1 [PT]
-    RewriteRule ^/v3/collection/(.*)  /phylesystem/v1/collection/$1 [PT]
+    # N.B. that we should match "bare" URLs like '/v3/collection' to create a resource!
+    RewriteRule ^/v3/collections(.*) /phylesystem/v1/collections$1 [PT]
+    RewriteRule ^/v3/collection(.*)  /phylesystem/v1/collection$1 [PT]
 
     # 7474 = treemachine neo4j
 
@@ -84,13 +86,15 @@
     # Public v2 API
 
     # phylesystem-api is provided via web2py
+    # N.B. that we should match "bare" URLs like '/v2/study' to create a resource!
     RewriteEngine on
-    RewriteRule ^/v2/study/(.*) /phylesystem/v1/study/$1 [PT]
+    RewriteRule ^/v2/study(.*) /phylesystem/v1/study$1 [PT]
 
     # collections-api is provided via web2py
+    # N.B. that we should match "bare" URLs like '/v2/collection' to create a resource!
     RewriteEngine on
-    RewriteRule ^/v2/collections/(.*) /phylesystem/v1/collections/$1 [PT]
-    RewriteRule ^/v2/collection/(.*)  /phylesystem/v1/collection/$1 [PT]
+    RewriteRule ^/v2/collections(.*) /phylesystem/v1/collections$1 [PT]
+    RewriteRule ^/v2/collection(.*)  /phylesystem/v1/collection$1 [PT]
 
     # 7474 = treemachine neo4j
 

--- a/test.sh
+++ b/test.sh
@@ -48,7 +48,7 @@ simple_curl_test tree_of_life/subtree '{"ott_id":876342}' "Alseuosmia_macrophyll
 
 simple_curl_test tree_of_life/induced_subtree '{"ott_ids":[901642, 55033]}' "Wittsteinia_panderi"
 
-simple_curl_test graph/about '{}' "graph_root_ott_id"
+simple_curl_test tree_of_life/about '{}' "root_ott_id"
 
 # Requires commit sha, which is hard to get
 if false; then

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-# Try out some v2 API methods
+# Try out some v3 API methods
 
 set -e
 
@@ -20,7 +20,7 @@ function simple_curl_test {
     method="$1"
     args="$2"
     checkfor="$3"
-    if curl --silent -X POST "$baseurl/v2/$method" -H "content-type:application/json" -d "$args" > curl.out; then
+    if curl --silent -X POST "$baseurl/v3/$method" -H "content-type:application/json" -d "$args" > curl.out; then
 	if grep -q "$checkfor" curl.out; then
 	    successes=$((successes + 1))
 	else
@@ -37,7 +37,7 @@ function simple_curl_test {
     fi
 }
 
-simple_curl_test tree_of_life/about '{"study_list":false}' root_ott_id
+simple_curl_test tree_of_life/about '{"study_list":false}' num_source_studies
 
 # 901642 = Alseuosmia banksii
 # 55033 = Wittsteinia panderi
@@ -48,21 +48,19 @@ simple_curl_test tree_of_life/subtree '{"ott_id":876342}' "Alseuosmia_macrophyll
 
 simple_curl_test tree_of_life/induced_subtree '{"ott_ids":[901642, 55033]}' "Wittsteinia_panderi"
 
-simple_curl_test tree_of_life/about '{}' "root_ott_id"
-
 # Requires commit sha, which is hard to get
 if false; then
     simple_curl_test graph/source_tree '{"study_id":"pg_41", "tree_id":"1396", "git_sha":"07054f960e6a5d42660af2bdda2fcc0a26120d71"}' "Lechenaultia_hirsuta"
 fi
 
 # Pegolettia senegalensis = 782981
-simple_curl_test graph/node_info '{"ott_id":782981}' "gbif:3139179"
+simple_curl_test tree_of_life/node_info '{"ott_id":782981}' "gbif:3139179"
 
 simple_curl_test tnrs/match_names '{"names":["Aster","Symphyotrichum","Erigeron"]}' "643717"
 
-simple_curl_test taxonomy/lica '{"ott_ids":[901642, 55033]}' 637370
+simple_curl_test taxonomy/mrca '{"ott_ids":[901642, 55033]}' 637370
 
-simple_curl_test taxonomy/taxon '{"ott_id":901642}' "Alseuosmia banksii"
+simple_curl_test taxonomy/taxon_info '{"ott_id":901642}' "Alseuosmia banksii"
 
 simple_curl_test studies/find_studies '{"property":"ot:studyId","value":"pg_41","verbose":true}' "Cariaga"
 


### PR DESCRIPTION
Includes
 - Removing trailing slashes from API rewrite rules
 - Changes to `CACHED_*` API URLs

The trailing slashes here caused API calls to fail (in v2 and v3) when trying to create resources in the RESTful style.