### PR TITLE
Add missing sed operation for CACHED_* base URLs

### DIFF
--- a/deploy/setup/install-web2py-apps.sh
+++ b/deploy/setup/install-web2py-apps.sh
@@ -124,6 +124,9 @@ sed "s+github_client_id = .*+github_client_id = $CURATION_GITHUB_CLIENT_ID+;
      s+collections_api_base_url = .*+opentree_api = $COLLECTIONS_API_BASE_URL+
      s+favorites_api_base_url = .*+opentree_api = $FAVORITES_API_BASE_URL+
      s+conflict_api = .*+conflict_api = $CONFLICT_BASE_URL+
+     s+CACHED_treemachine = .*+CACHED_treemachine = $CACHED_TREEMACHINE_BASE_URL+
+     s+CACHED_taxomachine = .*+CACHED_taxomachine = $CACHED_TAXOMACHINE_BASE_URL+
+     s+CACHED_oti = .*+CACHED_oti = $CACHED_OTI_BASE_URL+
      s+secure_sessions_with_HTTPS = .*+secure_sessions_with_HTTPS = $SSL_CERTS_FOUND+
     " < $configfile > tmp.tmp
 mv tmp.tmp $configfile


### PR DESCRIPTION
This restores cached responses for these API calls in the study curation
app:
  - /tnrs/contexts
  - /tree_of_life/about
(This change is tested and working as expected on **devtree**.)