### PR TITLE
Enable OTI v3 API

### DIFF
--- a/deploy/setup/install-neo4j-app.sh
+++ b/deploy/setup/install-neo4j-app.sh
@@ -97,8 +97,6 @@ function make_neo4j_instance {
 	if ./neo4j-$APP/bin/neo4j status; then
 	    echo "Stopping $APP neo4j server"
 	    ./neo4j-$APP/bin/neo4j stop
-            # Voodoo
-            sleep 3
 	fi
     else
         # There was some question as to whether the above code worked.

--- a/deploy/setup/install-neo4j-app.sh
+++ b/deploy/setup/install-neo4j-app.sh
@@ -97,6 +97,8 @@ function make_neo4j_instance {
 	if ./neo4j-$APP/bin/neo4j status; then
 	    echo "Stopping $APP neo4j server"
 	    ./neo4j-$APP/bin/neo4j stop
+            # Voodoo
+            sleep 3
 	fi
     else
         # There was some question as to whether the above code worked.

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -70,8 +70,8 @@
 
     <Location /v3/studies>
       Require all granted
-      ProxyPass  http://localhost:7478/db/data/ext/studies/graphdb
-      ProxyPassReverse  http://localhost:7478/db/data/ext/studies/graphdb
+      ProxyPass  http://localhost:7478/db/data/ext/studies_v3/graphdb
+      ProxyPassReverse  http://localhost:7478/db/data/ext/studies_v3/graphdb
     </Location>
 
     # 8081 = conflict service


### PR DESCRIPTION
That this change didn't get done when we released the rest of the v3 APIs was an oversight.

The only differences between v2 and v3 are
- some useless fields removed from result sets
- return 400 instead of {"error" ...} response
