### PR TITLE
Fix oti indexing

### DIFF
--- a/deploy/setup/index-doc-store.sh
+++ b/deploy/setup/index-doc-store.sh
@@ -43,6 +43,6 @@ echo "Indexing studies from API at $OPENTREE_API_BASE_URL"
 # We need to pass in the doc store repo name here
 # Need to explicitly run python since ours is different from what you get from #!/usr/bin/env
 
-time python repo/${APP}/index_current_repo.py http://127.0.0.1:7478/db/data/ext/studies_v3/graphdb ${OPENTREE_API_BASE_URL}v3
+time python repo/${APP}/index_current_repo.py http://127.0.0.1:7478/db/data/ext/studies_v3/graphdb ${OPENTREE_API_BASE_URL}phylesystem/v1
 
 log "$APP database indexed via $OPENTREE_API_BASE_URL"

--- a/deploy/setup/index-doc-store.sh
+++ b/deploy/setup/index-doc-store.sh
@@ -43,6 +43,6 @@ echo "Indexing studies from API at $OPENTREE_API_BASE_URL"
 # We need to pass in the doc store repo name here
 # Need to explicitly run python since ours is different from what you get from #!/usr/bin/env
 
-time python repo/$APP/index_current_repo.py http://127.0.0.1:7478/db/data/ $OPENTREE_API_BASE_URL
+time python repo/${APP}/index_current_repo.py http://127.0.0.1:7478/db/data/ext/studies_v3/graphdb ${OPENTREE_API_BASE_URL}v3
 
-log "$APP database initialized from $OPENTREE_API_BASE_URL and indexed"
+log "$APP database indexed via $OPENTREE_API_BASE_URL"


### PR DESCRIPTION
I've changed the way the oti index_current_repo.py script gets invoked to make it more flexible. E.g. now easy to test on a local oti instance with either local or remote phylesystem-api, without any special cases in the script. There is a new oti Makefile that does this.  See https://github.com/OpenTreeOfLife/oti/pull/57