### PR TITLE
Restart apache when updating neo4j databases.

### DIFF
--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -177,6 +177,8 @@ function docommand {
     install-db)
         if [ $# = 2 ]; then
             install_neo4j_db $*
+            # restart apache to clear the RAM cache (stale results)
+            restart_apache=yes
         else
             err "Wrong number of arguments to install-db" $*
         fi


### PR DESCRIPTION
This will clear stale results from the RAM cache, so we get fresh information (e.g. latest synth-tree version) on restart. This would happen correctly if we called the push script with component `treemachine`, but not when using the `install-db` command with treemachine as an argument.

[See related Gitter chat.](https://gitter.im/OpenTreeOfLife/public?at=5847029028d755bf14d112b4)