### PR TITLE
Support for API utility methods in v3

### DIFF
--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -55,6 +55,8 @@
     RewriteRule ^/v3/phylesystem_config /phylesystem/v1/phylesystem_config [PT]
     RewriteRule ^/v3/render_markdown /phylesystem/v1/render_markdown [PT]
     RewriteRule ^/v3/trees_in_synth /phylesystem/v1/trees_in_synth [PT]
+    RewriteRule ^/v3/include_tree_in_synth /phylesystem/v1/include_tree_in_synth [PT]
+    RewriteRule ^/v3/exclude_tree_from_synth /phylesystem/v1/exclude_tree_from_synth [PT]
 
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/tree_of_life>

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -50,6 +50,12 @@
     RewriteRule ^/v3/amendments(.*) /phylesystem/v1/amendments$1 [PT]
     RewriteRule ^/v3/amendment(.*)  /phylesystem/v1/amendment$1 [PT]
 
+    # some utility methods (undocumented) are mainly used by OpenTree webapps;
+    # these are provided by web2py, and typically unchanged since v1
+    RewriteRule ^/v3/phylesystem_config /phylesystem/v1/phylesystem_config [PT]
+    RewriteRule ^/v3/render_markdown /phylesystem/v1/render_markdown [PT]
+    RewriteRule ^/v3/trees_in_synth /phylesystem/v1/trees_in_synth [PT]
+
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/tree_of_life>
       Require all granted


### PR DESCRIPTION
Add support for all remaining undocumented API methods in v3 (intended for internal use only). This is working now on **devtree**, in tandem with the eponymous branch of `opentree` (web-apps). 