### PR TITLE
Restore web2py session sweepers

### DIFF
--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -62,6 +62,8 @@ echo "(Re)starting web2py session sweepers..."
 # Find and kill any sweepers that are already running
 sudo pkill -f sessions2trash
 # Now run a fresh instance in the background for each webapp
-sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
+echo "Logging sweeper activity in /home/admin/*-sweeper.log"
+# TODO: After testing, send all output to /dev/null instead of these logs
+sudo nohup 1>./webapp-sweeper.log   2>./webapp-sweeper.log   python $OPENTREE_HOME/web2py/web2py.py -S opentree --verbose -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py -A -v &
 # NOTE that we allow up to 24 hrs(!) before study-curation sessions will expire
-sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py --expiration=86400 &
+sudo nohup 1>./curation-sweeper.log 2>./curation-sweeper.log python $OPENTREE_HOME/web2py/web2py.py -S curator  --verbose -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py -A -v --expiration=86400 &

--- a/deploy/restart-apache.sh
+++ b/deploy/restart-apache.sh
@@ -55,19 +55,13 @@ fi
 echo "Restarting apache httpd..."
 sudo apache2ctl graceful || echo "apache2ctl failed"
 
-# One of these commands hangs after printing "(Re)starting web2py session sweeper..."
-# so for now I'm going to disable this code.  See 
-# https://github.com/OpenTreeOfLife/opentree/issues/845
-
-if false; then
-  echo "(Re)starting web2py session sweeper..."
-  # The sessions2trash.py utility script runs in the background, deleting expired
-  # sessions every 5 minutes. See documentation at
-  #   http://web2py.com/books/default/chapter/29/13/deployment-recipes#Cleaning-up-sessions
-  # Find and kill any sweepers that are already running
-  sudo pkill -f sessions2trash
-  # Now run a fresh instance in the background for each webapp
-  sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
-  # NOTE that we allow up to 24 hrs(!) before study-curation sessions will expire
-  sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py --expiration=86400 &
-fi
+echo "(Re)starting web2py session sweepers..."
+# The sessions2trash.py utility script runs in the background, deleting expired
+# sessions every 5 minutes. See documentation at
+#   http://web2py.com/books/default/chapter/29/13/deployment-recipes#Cleaning-up-sessions
+# Find and kill any sweepers that are already running
+sudo pkill -f sessions2trash
+# Now run a fresh instance in the background for each webapp
+sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S opentree -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py &
+# NOTE that we allow up to 24 hrs(!) before study-curation sessions will expire
+sudo nohup python $OPENTREE_HOME/web2py/web2py.py -S curator -M -R $OPENTREE_HOME/web2py/scripts/sessions2trash.py --expiration=86400 &


### PR DESCRIPTION
I realized a couple of problems that caused these to hang the push script. (Despite the `nohub` command, stdout and stderr were both holding onto the calling shell, so these are now diverted to log files in `/home/admin` (and eventually to `/dev/null`).

These are deployed and working now on **devtree**. Note that the `webapp-sweeper.log` file is very slow to record messages, but I believe it's working as expected.

Addresses https://github.com/OpenTreeOfLife/opentree/issues/845