### PR TITLE
Restrict http verbs

### DIFF
--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -79,7 +79,7 @@
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/tnrs>
       Require all granted
-      AllowMethods OPTIONS
+      AllowMethods OPTIONS POST
       ProxyPass  http://localhost:1983/v3/tnrs
       ProxyPassReverse  http://localhost:1983/v3/tnrs
     </Location>
@@ -87,7 +87,7 @@
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/taxonomy>
       Require all granted
-      AllowMethods OPTIONS
+      AllowMethods OPTIONS POST
       ProxyPass  http://localhost:1983/v3/taxonomy
       ProxyPassReverse  http://localhost:1983/v3/taxonomy
     </Location>
@@ -96,7 +96,7 @@
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/conflict>
       Require all granted
-      AllowMethods OPTIONS
+      AllowMethods OPTIONS POST
       ProxyPass  http://localhost:1983/v3/conflict
       ProxyPassReverse  http://localhost:1983/v3/conflict
     </Location>

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -17,6 +17,11 @@
 
     # See https://github.com/OpenTreeOfLife/opentree/wiki/Open-Tree-of-Life-APIs
 
+    <Location "/">
+        Require all denied
+        AllowMethods GET HEAD 
+    </Location>
+
     Alias "/taxonomy/browse" "/home/opentree/repo/opentree/taxonomy/cgi-bin/browse.py"
 
     <Directory "/home/opentree/repo/opentree/taxonomy/cgi-bin">
@@ -66,20 +71,23 @@
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/tree_of_life>
       Require all granted
+      AllowMethods OPTIONS POST
       ProxyPass  http://localhost:1983/v3/tree_of_life
       ProxyPassReverse  http://localhost:1983/v3/tree_of_life
     </Location>
 
-    # 7476 = taxomachine neo4j
+    # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/tnrs>
       Require all granted
-      ProxyPass  http://localhost:7476/db/data/ext/tnrs_v3/graphdb
-      ProxyPassReverse  http://localhost:7476/db/data/ext/tnrs_v3/graphdb
+      AllowMethods OPTIONS
+      ProxyPass  http://localhost:1983/v3/tnrs
+      ProxyPassReverse  http://localhost:1983/v3/tnrs
     </Location>
 
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/taxonomy>
       Require all granted
+      AllowMethods OPTIONS
       ProxyPass  http://localhost:1983/v3/taxonomy
       ProxyPassReverse  http://localhost:1983/v3/taxonomy
     </Location>
@@ -88,6 +96,7 @@
     # 1983 = ws_wrapper (around 1984: otc-tol-ws from otctera)
     <Location /v3/conflict>
       Require all granted
+      AllowMethods OPTIONS
       ProxyPass  http://localhost:1983/v3/conflict
       ProxyPassReverse  http://localhost:1983/v3/conflict
     </Location>


### PR DESCRIPTION
First pass at config changes to restrict http verbs. Also changes tnrs from neo4j to otcetera. Needs review to confirm 1) correct ports for otc and 2) which methods require opening up POST. 

Requires installation of [mod_allowmethods](https://httpd.apache.org/docs/2.4/mod/mod_allowmethods.html) module, if note already installed. 