### PR TITLE
Update germinator deployment for modern Ubuntu

### DIFF
--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -323,6 +323,10 @@ if [ ! -e $OTHOME/.ssh ]; then
 fi
 
 log ".ssh/authorized_keys created"
+
+# Update the canonical hostname on this server
+sudo hostnamectl set-hostname "$OPENTREE_HOST"
+
 # Ideally stowing the hostname one would be done every time, but we
 # want to avoid unsatisfiable sudo prompt demands, so let's assume it
 # stays the same.

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -49,6 +49,16 @@ function apt_get_install_one
     fi
 }
 
+# Add Bionic repository for these python2.* packages (in newer Ubuntu)
+#  python-venv (vs python3-venv)
+#  python-pip (vs python3-pip)
+#  python-requests (vs python3-requests)
+# These are required by our current version of web2py
+apt_get_install_one software-properties-common  # needed for add-apt-repository
+sudo apt-add-repository "deb http://us.archive.ubuntu.com/ubuntu/ bionic main universe"
+$APTGET update
+
+
 # ---------- UPDATE ----------
 
 if [ `which dialog`x = x ]; then
@@ -97,7 +107,8 @@ apt_get_install_one libboost-system-dev
 apt_get_install_one libtool
 apt_get_install_one pkg-config
 apt_get_install_one psmisc # for killall
-apt_get_install_one python3-venv
+apt_get_install_one elpa-pyvenv # for web2py
+apt_get_install_one python3-venv # for everyone else
 #apt_get_install_one g++-8
 apt_get_install_one ninja-build
 
@@ -174,6 +185,8 @@ fi
 # ---------- PIP ----------
 # Get pip
 if [ `which pip`x = x ]; then
+    apt_get_install --allow-downgrades python-pip-whl=9.0.1-2
+    # this python-pip dependency is very fussy about version
     apt_get_install python-pip
 fi
 
@@ -206,9 +219,9 @@ fi
 # ---------- PYTHON VIRTUALENV ----------
 # Get virtualenv
 if [ `which virtualenv`x = x ]; then
-    apt_get_install python-virtualenv virtualenv
+    # install for both python2 and python3
+    apt_get_install python-virtualenv python3-virtualenv virtualenv
 fi
-
 
 # ---------- MAVEN 3 ----------
 if [ `which mvn`x = x ]; then
@@ -225,7 +238,6 @@ fi
 if [ ! -r /etc/ntp.conf ]; then
     apt_get_install ntp
 fi
-
 
 # ---------- BACKUP EXISTING CONFIG FILES ---------
 

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -252,8 +252,10 @@ sudo cp --parents --preserve=all \
         /home/opentree/repo/opentree/curator/private/config \
         /home/opentree/repo/opentree/webapp/private/config \
         /home/phylesystemapi/repo/phylesystem-api/private/config \
-        $CONFIG_BACKUP_DIR 2>/dev/null
-
+        $CONFIG_BACKUP_DIR 2>/dev/null || true
+# NB the final '|| true' (alternately, '|| :') makes sure we keep on running even if
+# any of the above source files are missing. Else this script fails silently before
+# doing the steps below!
 
 # ---------- APACHE VHOST ----------
 

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -14,6 +14,13 @@ OPENTREE_USER=$2
 CERTIFICATE_FILE=$3
 CERTIFICATE_KEY_FILE=$4
 
+# copied from setup/functions.sh (not yet available), so we can log admin stuff
+ADMIN_HOME=$(bash <<< "echo ~")
+function log() {
+    mkdir -p "$ADMIN_HOME/log" || exit 1
+    (echo `date` as-admin.sh: " $*") >>"$ADMIN_HOME/log/messages"  || exit
+}
+
 if [ x$OPENTREE_USER = x ]; then
     OPENTREE_USER=opentree
 fi
@@ -287,6 +294,8 @@ else
     sudo rm -f /etc/apache2/sites-enabled/001-opentree-ssl.conf
 fi
 
+log "before UNPRIVILEGED USER"
+
 # Apache 2.4 is finicky about protection of the key file
 
 
@@ -304,6 +313,8 @@ if [ ! -e $OTHOME ]; then
     sudo chsh -s /bin/bash $OPENTREE_USER
 fi
 
+log "OPENTREE_USER added"
+
 if [ ! -e $OTHOME/.ssh ]; then
     sudo mkdir $OTHOME/.ssh
     sudo cp -p .ssh/authorized_keys $OTHOME/.ssh/
@@ -311,6 +322,7 @@ if [ ! -e $OTHOME/.ssh ]; then
     sudo chown -R $OPENTREE_USER:$OPENTREE_USER $OTHOME
 fi
 
+log ".ssh/authorized_keys created"
 # Ideally stowing the hostname one would be done every time, but we
 # want to avoid unsatisfiable sudo prompt demands, so let's assume it
 # stays the same.
@@ -322,4 +334,8 @@ if [ x$OPENTREE_HOST != x -a ! -r $OTHOME/hostname ]; then
 	chmod go+r $HOSTFILE
 	chown $OPENTREE_USER $HOSTFILE
 EOF
+
+    log "hostname updated to $OPENTREE_HOST"
 fi
+
+log "did we SKIP the hostname?"

--- a/deploy/as-admin.sh
+++ b/deploy/as-admin.sh
@@ -244,8 +244,8 @@ fi
 # Copy all possible Open Tree config files. A given target machine will have
 # some but not all of these, so suppress "file not found" messages.
 CONFIG_BACKUP_DIR="/home/admin/otol-backups.$(date +'%b-%d-%Y-%H%M%S')"
-mkdir -p $CONFIG_BACKUP_DIR
-cp --parents --preserve=all \
+sudo mkdir -p $CONFIG_BACKUP_DIR
+sudo cp --parents --preserve=all \
         /etc/apache2/sites-available/opentree.conf \
         /etc/apache2/sites-available/opentree-ssl.conf \
         /etc/apache2/opentree-shared.conf \

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -80,10 +80,10 @@ done
 [ "x$OPENTREE_HOST" != x ] || err "OPENTREE_HOST not specified"
 
 # On ubuntu, the admin user is called 'ubuntu'; on debian it's 'admin'
-[ "x$OPENTREE_ADMIN" != x ] || OPENTREE_ADMIN=admin
+[ "x$OPENTREE_ADMIN" != x ] || OPENTREE_ADMIN=ubuntu
 
 # Unprivileged user that runs all the services
-[ "x$OPENTREE_USER" != x ] || OPENTREE_USER=opentree
+[ "x$OPENTREE_USER" != x ] || OPENTREE_USER=deploy
 
 # OPENTREE_SECRETS is the *local* directory where .pem and other
 # private files are kept

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -280,9 +280,21 @@ function sync_system {
     if [ $DRYRUN = "yes" ]; then echo "[sync]"; return; fi
     # Do privileged stuff
     # Don't use rsync - might not be installed yet
+
+    ##echo ">>>>>>>>>>>>"
+    ##echo "BEFORE as-admin.sh..."
+    ##echo "  scp -p -i '${ADMIN_IDENTITY}' as-admin.sh '$OPENTREE_ADMIN@$OPENTREE_HOST':"
+    ##echo "  ${ASSH} '$ADMIN@$OPENTREE_HOST' ./as-admin.sh '$OPENTREE_HOST' '$OPENTREE_USER' '$CERTIFICATE_FILE' '$CERTIFICATE_KEY_FILE'"
+    ## echo ">>>>>>>>>>>>"
+
     scp -p -i "${ADMIN_IDENTITY}" as-admin.sh "$OPENTREE_ADMIN@$OPENTREE_HOST":
     ${ASSH} "$ADMIN@$OPENTREE_HOST" ./as-admin.sh "$OPENTREE_HOST" "$OPENTREE_USER" \
        "$CERTIFICATE_FILE" "$CERTIFICATE_KEY_FILE"
+
+    ##echo "<<<<<<<<<<<<"
+    ##echo "AFTER as-admin.sh!"
+    ##echo "<<<<<<<<<<<<"
+
     # Copy files over
     rsync -pr -e "${SSH}" "--exclude=*~" "--exclude=#*" setup "$OT_USER@$OPENTREE_HOST":
     # Bleh

--- a/deploy/setup/opentree-shared.conf
+++ b/deploy/setup/opentree-shared.conf
@@ -26,7 +26,7 @@
 
     Alias "/taxonomy/browse" "/home/opentree/repo/opentree/taxonomy/cgi-bin/browse.py"
 
-    <Directory "/home/opentree/repo/opentree/taxonomy/cgi-bin">
+    <Directory "/home/deploy/repo/opentree/taxonomy/cgi-bin">
       Require all granted
       Options +ExecCGI
       AddHandler cgi-script .py

--- a/deploy/setup/opentree-ssl.conf
+++ b/deploy/setup/opentree-ssl.conf
@@ -43,14 +43,14 @@
     # Moving all WSGI configuration here, so we only run one instance of web2py on HTTPS.
     # This should prevent our broken session problem as documented here:
     #   https://github.com/OpenTreeOfLife/opentree/issues/804
-    WSGIDaemonProcess web2py user=opentree group=opentree display-name=%{GROUP}
+    WSGIDaemonProcess web2py user=deploy group=deploy display-name=%{GROUP}
     WSGIProcessGroup web2py
-    WSGIScriptAlias / /home/opentree/web2py/wsgihandler.py
+    WSGIScriptAlias / /home/deploy/web2py/wsgihandler.py
 
     # We don't want the scriptalias to override mappings for
     #  treemachine and taxomachine... seems not to.
 
-    <Directory /home/opentree/web2py>
+    <Directory /home/deploy/web2py>
       AllowOverride None
       Require all denied
       <Files wsgihandler.py>
@@ -58,8 +58,8 @@
       </Files>
     </Directory>
 
-    AliasMatch ^/([^/]+)/static/(.*)            /home/opentree/web2py/applications/$1/static/$2
-    <Directory /home/opentree/web2py/applications/*/static/>
+    AliasMatch ^/([^/]+)/static/(.*)            /home/deploy/web2py/applications/$1/static/$2
+    <Directory /home/deploy/applications/*/static/>
       Require all granted
     </Directory>
 

--- a/deploy/setup/web2py-patches/oauth20_account.py
+++ b/deploy/setup/web2py-patches/oauth20_account.py
@@ -83,7 +83,7 @@ class OAuthAccount(object):
                user = None
                try:
                    user = self.graph.get_object("me")
-               except GraphAPIError, e:
+               except GraphAPIError as e:
                    self.session.token = None
                    self.graph = None
 
@@ -226,7 +226,7 @@ server for requests.  It can be used for the optional"scope" parameters for Face
                     opener.close()
                 try:
                     return current.session.token['access_token']
-                except Exception, e:
+                except Exception as e:
                     raise Exception("No access_token found in data: %s %s" % (current.session.token, e))
                     return None
 

--- a/doc/ot-synthesis-v10.2.md
+++ b/doc/ot-synthesis-v10.2.md
@@ -3,10 +3,10 @@
 Version 10.2 of the synthetic tree was generated on 9 January 2018 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree10.2/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree10.2/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree10.2/opentree10.2_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree10.2/opentree10.2_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree10.2/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree10.2/opentree10.2_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree10.2/opentree10.2_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree10.2/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v10.3.md
+++ b/doc/ot-synthesis-v10.3.md
@@ -5,8 +5,8 @@ Version 10.3 of the synthetic tree was generated on 10 July 2018 using the [prop
 ## Downloads
 There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree10.3/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree10.3/opentree10.3_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree10.3/opentree10.3_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree10.3/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree10.3/opentree10.3_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree10.3/opentree10.3_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree10.3/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v10.4.md
+++ b/doc/ot-synthesis-v10.4.md
@@ -3,10 +3,10 @@
 Version 10.4 of the synthetic tree was generated on 24 September 2018 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree10.4/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree10.4/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree10.4/opentree10.4_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree10.4/opentree10.4_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree10.4/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree10.4/opentree10.4_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree10.4/opentree10.4_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree10.4/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v11.4.md
+++ b/doc/ot-synthesis-v11.4.md
@@ -3,10 +3,10 @@
 Version 11.4 of the synthetic tree was generated on 09 October 2019 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree11.4/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree11.4/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree11.4/opentree11.4_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 40 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree11.4/opentree11.4_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree11.4/output/index.html) rather than downloading. (compressed tar archive; 301 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree11.4/opentree11.4_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 40 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree11.4/opentree11.4_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree11.4/output/index.html) rather than downloading. (compressed tar archive; 301 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v12.3.md
+++ b/doc/ot-synthesis-v12.3.md
@@ -3,10 +3,10 @@
 Version 12.3 of the synthetic tree was generated on 23 December 2019 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree12.3/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree12.3/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree12.3/opentree12.3_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 40 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree12.3/opentree12.3_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree12.3/output/index.html) rather than downloading. (compressed tar archive; 301 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree12.3/opentree12.3_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 40 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree12.3/opentree12.3_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree12.3/output/index.html) rather than downloading. (compressed tar archive; 301 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v13.4.md
+++ b/doc/ot-synthesis-v13.4.md
@@ -3,10 +3,10 @@
 Version 13.4 of the synthetic tree was generated on 18 June 2021 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree13.4/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree13.4/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree13.4/opentree13.4tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 36 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree13.4/opentree13.4.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree13.4/output/index.html) rather than downloading. (compressed tar archive; 561 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree13.4/opentree13.4tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 36 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree13.4/opentree13.4.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree13.4/output/index.html) rather than downloading. (compressed tar archive; 561 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v5.0.md
+++ b/doc/ot-synthesis-v5.0.md
@@ -4,11 +4,11 @@ Version 5.0 was generated on 28 March 2016.
 
 ## Downloads
 
-* [Synthetic tree](http://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_tree.tgz) : includes the full tree, annotations file, and a phylo-only tree (tips only from taxonomy pruned off). See the enclosed README for details. (compressed tar archive; 9 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. You can also [browse the contents](http://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) rather than downloading. (compressed tar archive; 68 Mbyes)
+* [Synthetic tree](https://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_tree.tgz) : includes the full tree, annotations file, and a phylo-only tree (tips only from taxonomy pruned off). See the enclosed README for details. (compressed tar archive; 9 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. You can also [browse the contents](https://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) rather than downloading. (compressed tar archive; 68 Mbyes)
 
 ## Release notes
 
 This version of the tree was generated with a completely new synthesis method. There is a [make-based pipeline](https://github.com/OpenTreeOfLife/propinquity) that uses functions from the [otcetera library](https://github.com/OpenTreeOfLife/otcetera).
 
-The method is currently unpublished, but the [documentation pages](http://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) have detailed descriptions of all steps, with links to inputs and outputs. There is also a [draft manuscript](https://github.com/OpenTreeOfLife/otcetera/blob/master/doc/summarizing-taxonomy-plus-trees.tex) (tex format).
+The method is currently unpublished, but the [documentation pages](https://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) have detailed descriptions of all steps, with links to inputs and outputs. There is also a [draft manuscript](https://github.com/OpenTreeOfLife/otcetera/blob/master/doc/summarizing-taxonomy-plus-trees.tex) (tex format).

--- a/doc/ot-synthesis-v5.md
+++ b/doc/ot-synthesis-v5.md
@@ -4,11 +4,11 @@ Version 5.0 was generated on 28 March 2016.
 
 ## Downloads
 
-* [Synthetic tree](http://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_tree.tgz) : includes the full tree, annotations file, and a phylo-only tree (tips only from taxonomy pruned off). See the enclosed README for details. (compressed tar archive; 9 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. You can also [browse the contents](http://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) rather than downloading. (compressed tar archive; 68 Mbyes)
+* [Synthetic tree](https://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_tree.tgz) : includes the full tree, annotations file, and a phylo-only tree (tips only from taxonomy pruned off). See the enclosed README for details. (compressed tar archive; 9 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree5.0/opentree5.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. You can also [browse the contents](https://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) rather than downloading. (compressed tar archive; 68 Mbyes)
 
 ## Release notes
 
 This version of the tree was generated with a completely new synthesis method. There is a [make-based pipeline](https://github.com/OpenTreeOfLife/propinquity) that uses functions from the [otcetera library](https://github.com/OpenTreeOfLife/otcetera).
 
-The method is currently unpublished, but the [documentation pages](http://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) have detailed descriptions of all steps, with links to inputs and outputs. There is also a [draft manuscript](https://github.com/OpenTreeOfLife/otcetera/blob/master/doc/summarizing-taxonomy-plus-trees.tex) (tex format).
+The method is currently unpublished, but the [documentation pages](https://files.opentreeoflife.org/synthesis/opentree5.0/output/index.html) have detailed descriptions of all steps, with links to inputs and outputs. There is also a [draft manuscript](https://github.com/OpenTreeOfLife/otcetera/blob/master/doc/summarizing-taxonomy-plus-trees.tex) (tex format).

--- a/doc/ot-synthesis-v6.1.md
+++ b/doc/ot-synthesis-v6.1.md
@@ -3,10 +3,10 @@
 Version 6.1 of the synthetic tree was generated on 2 August 2016 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree6.1/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree6.1/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree6.1/opentree6.1_tree.tar.gz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 32 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree6.1/opentree6.1_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree6.1/output/index.html) rather than downloading. (compressed tar archive; 138 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree6.1/opentree6.1_tree.tar.gz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 32 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree6.1/opentree6.1_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree6.1/output/index.html) rather than downloading. (compressed tar archive; 138 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v7.0.md
+++ b/doc/ot-synthesis-v7.0.md
@@ -3,10 +3,10 @@
 Version 7.0 of the synthetic tree was generated on 11 September 2016 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree7.0/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree7.0/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree7.0/opentree7.0_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 49 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree7.0/opentree7.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree7.0/output/index.html) rather than downloading. (compressed tar archive; 128 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree7.0/opentree7.0_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 49 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree7.0/opentree7.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree7.0/output/index.html) rather than downloading. (compressed tar archive; 128 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v8.0.md
+++ b/doc/ot-synthesis-v8.0.md
@@ -3,10 +3,10 @@
 Version 8.0 of the synthetic tree was generated on 29 November 2016 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree8.0/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree8.0/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree8.0/opentree8.0_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 29 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree8.0/opentree8.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree8.0/output/index.html) rather than downloading. (compressed tar archive; 151 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree8.0/opentree8.0_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 29 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree8.0/opentree8.0_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree8.0/output/index.html) rather than downloading. (compressed tar archive; 151 Mbytes)
 
 ## Release notes
 

--- a/doc/ot-synthesis-v9.1.md
+++ b/doc/ot-synthesis-v9.1.md
@@ -3,10 +3,10 @@
 Version 9.1 of the synthetic tree was generated on 22 March 2017 using the [propinquity pipeline](https://github.com/OpenTreeOfLife/propinquity).
 
 ## Downloads
-There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](http://files.opentreeoflife.org/synthesis/opentree9.1/output/index.html).
+There are two downloads. The first (smaller download) contain only tree and annotations files. The second (larger download) is the full output from the synthesis procedure, including documentation. You can also [browse the full output](https://files.opentreeoflife.org/synthesis/opentree9.1/output/index.html).
 
-* [Tree and annotations](http://files.opentreeoflife.org/synthesis/opentree9.1/opentree9.1_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
-* [All pipeline outputs](http://files.opentreeoflife.org/synthesis/opentree9.1/opentree9.1_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](http://files.opentreeoflife.org/synthesis/opentree9.1/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
+* [Tree and annotations](https://files.opentreeoflife.org/synthesis/opentree9.1/opentree9.1_tree.tgz) : Several versions of the synthetic tree, along with the annotations file. See the enclosed README for details. (compressed tar archive; 35 Mbytes)
+* [All pipeline outputs](https://files.opentreeoflife.org/synthesis/opentree9.1/opentree9.1_output.tgz) : Outputs and documentation from all stages of the synthesis pipeline. Or, you can [browse the output](https://files.opentreeoflife.org/synthesis/opentree9.1/output/index.html) rather than downloading. (compressed tar archive; 189 Mbytes)
 
 ## Release notes
 

--- a/ws-tests/run_tests.sh
+++ b/ws-tests/run_tests.sh
@@ -58,6 +58,9 @@ fi
 
 first_config_spec=$1
 shift
+echo '+ first_config_spec:'
+echo $first_config_spec
+echo '+'
 
 if [[ ! "$first_config_spec" =~ "=" ]]; then
     if [[ "$first_config_spec" =~ ^http: ]]; then
@@ -71,6 +74,11 @@ config_specs="$first_config_spec $*"
 if [[ ! "$config_specs" =~ "host:allowwrite=" ]]; then
     config_specs="$first_config_spec $* host:allowwrite=false"
 fi
+echo '+'
+echo '+ config_specs:'
+echo $config_specs
+echo '+'
+echo '+'
 
 
 # The python test scripts all use the opentreetesting.py library,


### PR DESCRIPTION
This is necessary for now, since we need to deploy old web-apps etc. on new Ubuntu servers.